### PR TITLE
Fixed display page error for tokens with decimal place

### DIFF
--- a/explorer/src/components/account/TokenAccountSection.tsx
+++ b/explorer/src/components/account/TokenAccountSection.tsx
@@ -209,7 +209,7 @@ function FungibleTokenMintAccountCard({
               {normalizeTokenAmount(info.supply, info.decimals).toLocaleString(
                 "en-US",
                 {
-                  minimumFractionDigits: info.decimals,
+                  maximumFractionDigits: 20,
                 }
               )}
             </td>


### PR DESCRIPTION
#### Problem
Explorer was crashing in pages of tokens with large decimal places [25756](https://github.com/solana-labs/solana/issues/25756)

#### Summary of Changes
Added maximumFractionDigits of 20 as that's the maximum limit for the `toLocaleString` function.